### PR TITLE
Fix a bug when caller subscribes events for checking Login completion…

### DIFF
--- a/source/EnRouteApiAndroid/Source/ClassBinder.cs
+++ b/source/EnRouteApiAndroid/Source/ClassBinder.cs
@@ -63,6 +63,14 @@ namespace Glympse.EnRoute.Android
                 {
                     return new Operation(Extensions.JavaCast<com.glympse.enroute.android.api.GOperation>(obj));
                 }
+                else if ("java.lang.String" == obj.Class.Name)
+                {
+                    return Extensions.JavaCast<Java.Lang.String>(obj).ToString();
+                }
+                else if ("java.lang.Long" == obj.Class.Name)
+                {
+                    return Extensions.JavaCast<Java.Lang.Long>(obj).LongValue();
+                }
                 else
                 {
                     throw new Exception("Unsupported type: " + obj.Class.Name);


### PR DESCRIPTION
… and when users logins with invalid user name and passwords, the enroute-xamarin-sdk throws and unsupported type exceptions.