### PR TITLE
GlyLong iOS Implementation

### DIFF
--- a/source/EnRouteApiiOS/ApiDefinition.cs
+++ b/source/EnRouteApiiOS/ApiDefinition.cs
@@ -417,5 +417,13 @@ namespace Glympse.EnRoute.iOS
         [Export ("createEnRouteManager")]
         GlyEnRouteManager createEnRouteManager();       
     }
+
+	[BaseType(typeof(GlyCommon))]
+	[DisableDefaultCtor]
+	interface GlyLong
+	{
+        [Export ("longValue")]
+        long longValue();
+	}
 }
 

--- a/source/EnRouteApiiOS/ApiDefinition.cs
+++ b/source/EnRouteApiiOS/ApiDefinition.cs
@@ -274,7 +274,10 @@ namespace Glympse.EnRoute.iOS
         string getDescription();
 
         [Export ("getDueTime")]
-        long getDueTime();        
+        long getDueTime();
+
+		[Export("getForeignId")]
+		string getForeignId();
     }
 
     [BaseType (typeof(GlyCommon))]

--- a/source/EnRouteApiiOS/EnRouteApi.iOS.csproj
+++ b/source/EnRouteApiiOS/EnRouteApi.iOS.csproj
@@ -32,6 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Runtime" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>

--- a/source/EnRouteApiiOS/Source/ClassBinder.cs
+++ b/source/EnRouteApiiOS/Source/ClassBinder.cs
@@ -44,6 +44,10 @@ namespace Glympse.EnRoute.iOS
             {
                 return ((Foundation.NSNumber) raw).LongValue;
             }
+			else if (raw is GlyLong)
+			{
+                return ((GlyLong)raw).longValue();
+			}
             else if ( raw is GlyPrimitive )
             {
                 return new Primitive((GlyPrimitive)raw);


### PR DESCRIPTION
When using the Enroute.iOS Xamarin library, an event would arrive to be handled in the `eventsOccured` method of the `Glympse.EnRoute.iOS.ListenerWrapper` class.

This would cause an Exception to be thrown in our application. We obtained the Enroute.iOS library and referenced the source rather than the library DLL. Doing this, we discovered the Exception was coming from `ClassBinder`, which did not know how to bind the type arriving, which was a `GlyLong`.

The `param1` parameter of type `GlyCommon` was the culprit: this was a `GlyLong`. Referencing what we found at https://developer.glympse.com/docs/core/client-sdk/reference/ios/Long, we created an implementation of `GlyLong` within `ApiDefinition.cs` and added a clause to `Classbinder`.

This appears to solve the problem, we now receive the event properly, with no Exception.