### PR TITLE
Fix/system runtime reference

### DIFF
--- a/source/EnRouteApiiOS/EnRouteApi.iOS.csproj
+++ b/source/EnRouteApiiOS/EnRouteApi.iOS.csproj
@@ -32,6 +32,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
@gwyddion39  This appears to fix the issue with Visual Studio not being able to compile the project. I couldn't figure out how to make it work if I tried to add the reference through VS, but I added it manually and it builds now.