### PR TITLE
Adding a reference to System.Runtime and System.Core in EnRouteApi.iO…

### DIFF
--- a/source/EnRouteApiiOS/EnRouteApi.iOS.csproj
+++ b/source/EnRouteApiiOS/EnRouteApi.iOS.csproj
@@ -32,6 +32,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Core" />
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
…S.csproj required for usage of IEnumerable interface.