### PR TITLE
Feature/adding config notification customization

### DIFF
--- a/samples/EnRouteDemo/GlympseWrapper.cs
+++ b/samples/EnRouteDemo/GlympseWrapper.cs
@@ -44,6 +44,7 @@ namespace EnRouteDemo
             _glympse = glympseFactory.createGlympse(BASE_URL, API_KEY);
             _glympse.overrideLoggingLevels(1, 1); // Increases logging levels. Turn off for production deployments
             _glympse.getConsentManager().exemptFromConsent(true);
+            _glympse.getConfig().setActiveSharingNotificationMessage("This message will show in your notifcation");
             _glympse.start();
         }
 

--- a/source/EnRouteApi/EnRouteApi.csproj
+++ b/source/EnRouteApi/EnRouteApi.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Source\Core\GCoreFactory.cs" />
     <Compile Include="Source\Core\GCardMessage.cs" />
     <Compile Include="Source\Core\GCardMessages.cs" />
+    <Compile Include="Source\Core\GConfig.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/source/EnRouteApi/Source/Core/GConfig.cs
+++ b/source/EnRouteApi/Source/Core/GConfig.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Glympse
+{
+    public interface GConfig : GCommon
+    {
+        void setActiveSharingNotificationMessage(string message);
+    }
+}

--- a/source/EnRouteApi/Source/Core/GGlympse.cs
+++ b/source/EnRouteApi/Source/Core/GGlympse.cs
@@ -31,5 +31,7 @@ namespace Glympse
         string getApiVersion();
 
         void overrideLoggingLevels(int fileLevel, int debugLevel);
+
+        GConfig getConfig();
     }
 }

--- a/source/EnRouteApi/Source/EnRoute/EnRouteEvents.cs
+++ b/source/EnRouteApi/Source/EnRoute/EnRouteEvents.cs
@@ -132,6 +132,32 @@ namespace EnRoute
     public const int ENROUTE_MANAGER_SELF_AGENT_UPDATED = 0x00000100;
     
     /**
+     * This event is broadcast when the self agent's shift starts
+     *
+     */
+    public const int ENROUTE_MANAGER_SHIFT_STARTED = 0x00000200;
+    
+    /**
+     * This event is broadcast when the self agent's shift completes
+     *
+     */
+    public const int ENROUTE_MANAGER_SHIFT_COMPLETED = 0x00000400;
+    
+    /**
+     * This event is broadcast when the self agent's shift fails to start
+     *
+     * param1: error (GString)
+     */
+    public const int ENROUTE_MANAGER_SHIFT_START_FAILED = 0x00000800;
+    
+    /**
+     * This event is broadcast when the self agent's shift fails to complete
+     *
+     * param1: error (GString)
+     */
+    public const int ENROUTE_MANAGER_SHIFT_COMPLETE_FAILED = 0x00001000;
+    
+    /**
      * @name Task Manager events.
      *
      * Events broadcasted by LISTENER_TASKS.
@@ -266,7 +292,7 @@ namespace EnRoute
      * 
      * The reason for failusre is passed as a parameter (string).
      */
-    public const int AGENTS_AGENT_UPDATE_FAILED = 0x000000010;
+    public const int AGENTS_AGENT_UPDATE_FAILED = 0x00000010;
     
     /**
      * @name Session Manager events.

--- a/source/EnRouteApiAndroid/EnRouteApi.Android.csproj
+++ b/source/EnRouteApiAndroid/EnRouteApi.Android.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Source\ConsentManager.cs" />
     <Compile Include="Source\CardMessage.cs" />
     <Compile Include="Source\CardMessages.cs" />
+    <Compile Include="Source\Config.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Additions\AboutAdditions.txt" />

--- a/source/EnRouteApiAndroid/Source/Config.cs
+++ b/source/EnRouteApiAndroid/Source/Config.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Glympse.EnRoute.Android
+{
+    class Config : GConfig
+    {
+        private com.glympse.android.api.GConfig _raw;
+
+        public Config(com.glympse.android.api.GConfig raw)
+        {
+            _raw = raw;
+        }
+
+        public void setActiveSharingNotificationMessage(string message)
+        {
+            _raw.setActiveSharingNotificationMessage(message);
+        }
+
+        public object raw()
+        {
+            return _raw;
+        }
+    }
+}

--- a/source/EnRouteApiAndroid/Source/Glympse.cs
+++ b/source/EnRouteApiAndroid/Source/Glympse.cs
@@ -81,6 +81,11 @@ namespace Glympse.EnRoute.Android
             _raw.overrideLoggingLevels(fileLevel, debugLevel);
         }
 
+        public GConfig getConfig()
+        {
+            return new Config((com.glympse.android.api.GConfig)_raw.getConfig());
+        }
+
         public object raw()
         {
             return _raw;

--- a/source/EnRouteApiAndroid/Transforms/Metadata.xml
+++ b/source/EnRouteApiAndroid/Transforms/Metadata.xml
@@ -203,6 +203,9 @@
     <attr 
         path="/api/package[@name='com.glympse.android.api']/interface[@name='GGlympse']/method[@name='overrideLoggingLevels']" 
         name="managedName">overrideLoggingLevels</attr>
+    <attr 
+        path="/api/package[@name='com.glympse.android.api']/interface[@name='GGlympse']/method[@name='getConfig']" 
+        name="managedName">getConfig</attr>
     
     <!-- GPlace -->
     <attr 
@@ -303,6 +306,14 @@
     <attr 
         path="/api/package[@name='com.glympse.android.api']/interface[@name='GCardMessage']/method[@name='isRead']" 
         name="managedName">isRead</attr>
+    
+    <!-- GConfig -->
+    <attr 
+        path="/api/package[@name='com.glympse.android.api']/interface[@name='GConfig']" 
+        name="managedName">GConfig</attr>
+    <attr 
+        path="/api/package[@name='com.glympse.android.api']/interface[@name='GConfig']/method[@name='setActiveSharingNotificationMessage']" 
+        name="managedName">setActiveSharingNotificationMessage</attr>
     
     <!-- GUserManager -->
     <attr 

--- a/source/EnRouteApiiOS/ApiDefinition.cs
+++ b/source/EnRouteApiiOS/ApiDefinition.cs
@@ -287,6 +287,9 @@ namespace Glympse.EnRoute.iOS
 
         [Export("overrideLoggingLevels:debugLevel:")]
         void overrideLoggingLevels(int fileLevel, int debugLevel);
+
+        [Export("getConfig")]
+        GlyConfig getConfig();
     }
 
     [BaseType(typeof(GlyCommon))]
@@ -392,6 +395,14 @@ namespace Glympse.EnRoute.iOS
 
         [Export("isRead")]
         bool isRead();
+    }
+
+    [BaseType(typeof(NSObject))]
+    [DisableDefaultCtor]
+    interface GlyConfig
+    {
+        [Export("setActiveSharingNotificationMessage:")]
+        void setActiveSharingNotificationMessage(string message);
     }
 
     [BaseType(typeof(NSObject))]

--- a/source/EnRouteApiiOS/EnRouteApi.iOS.csproj
+++ b/source/EnRouteApiiOS/EnRouteApi.iOS.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Source\ConsentManager.cs" />
     <Compile Include="Source\CardMessages.cs" />
     <Compile Include="Source\CardMessage.cs" />
+    <Compile Include="Source\Config.cs" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingApiDefinition Include="ApiDefinition.cs" />

--- a/source/EnRouteApiiOS/Source/Config.cs
+++ b/source/EnRouteApiiOS/Source/Config.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Glympse.EnRoute.iOS
+{
+    class Config : GConfig
+    {
+        private GlyConfig _raw;
+
+        public Config(GlyConfig raw)
+        {
+            _raw = raw;
+        }
+
+        public void setActiveSharingNotificationMessage(string message)
+        {
+            _raw.setActiveSharingNotificationMessage(message);
+        }
+
+        public object raw()
+        {
+            return _raw;
+        }
+    }
+}

--- a/source/EnRouteApiiOS/Source/Glympse.cs
+++ b/source/EnRouteApiiOS/Source/Glympse.cs
@@ -81,6 +81,11 @@ namespace Glympse.EnRoute.iOS
             _raw.overrideLoggingLevels(fileLevel, debugLevel);
         }
 
+        public GConfig getConfig()
+        {
+            return new Config((GlyConfig)_raw.getConfig());
+        }
+
         public object raw()
         {
             return _raw;


### PR DESCRIPTION
Added Config class.
Added getConfig() method to GGlympse.
Added setActiveSharingNotificationMessage to GConfig (only used by Android).

Small update to the demo to show how to use a custom notification message in Android.